### PR TITLE
Create accounts upfront (required due to autofund removal)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,15 @@
   "dependencies": {
     "bluebird": "^3.3.0",
     "bluebird-co": "^2.1.2",
+    "byline": "^4.2.1",
+    "chalk": "^1.1.3",
     "co-mocha": "^1.1.2",
     "five-bells-condition": "^3.0.0",
     "mocha": "^2.4.5",
     "node-fetch": "^1.3.3",
     "superagent": "^1.7.2",
+    "supports-color": "^3.1.2",
+    "through2": "^2.0.1",
     "wait-on": "^1.3.1"
   }
 }

--- a/src/tests/advanced.js
+++ b/src/tests/advanced.js
@@ -11,240 +11,242 @@ const notarySecretKey = 'lRmSmT/I2SS5I7+FnFgHbh8XZuu4NeL0wk8oN86L50U='
 const notaryPublicKey = '4QRmhUtrxlwQYaO+c8K2BtCd6c4D8HVmy5fLDSjsH6A='
 const receiverSecret = 'O8Y6+6bJgl2i285yCeC/Wigi6P6TJ4C78tdASqDOR9g='
 
-before(function * () {
-  yield graph.startLedger('ledger2_1', 3101, {scale: 4})
-  yield graph.startLedger('ledger2_2', 3102, {scale: 2})
-  yield graph.startLedger('ledger2_3', 3103, {scale: 4})
-  yield graph.startLedger('ledger2_4', 3104, {scale: 4})
+describe('Advanced', function () {
+  before(function * () {
+    yield graph.startLedger('ledger2_1', 3101, {scale: 4})
+    yield graph.startLedger('ledger2_2', 3102, {scale: 2})
+    yield graph.startLedger('ledger2_3', 3103, {scale: 4})
+    yield graph.startLedger('ledger2_4', 3104, {scale: 4})
 
-  yield graph.startLedger('ledger2_5', 3105, {scale: 4})
-  yield graph.startLedger('ledger2_6', 3106, {scale: 4})
-  yield graph.startLedger('ledger2_7', 3107, {scale: 4})
+    yield graph.startLedger('ledger2_5', 3105, {scale: 4})
+    yield graph.startLedger('ledger2_6', 3106, {scale: 4})
+    yield graph.startLedger('ledger2_7', 3107, {scale: 4})
 
-  yield graph.setupAccounts()
+    yield graph.setupAccounts()
 
-  yield graph.startConnector('mark2', 4101, {
-    edges: [{source: 'http://localhost:3101', target: 'http://localhost:3102'}]
-  })
-
-  yield graph.startConnector('mary2', 4102, {
-    edges: [{source: 'http://localhost:3101', target: 'http://localhost:3103'}],
-    slippage: '0'
-  })
-
-  yield graph.startConnector('martin2', 4103, {
-    edges: [{source: 'http://localhost:3101', target: 'http://localhost:3104'}],
-    fxSpread: '0.5'
-  })
-
-  yield graph.startConnector('millie2', 4104, {
-    edges: [{source: 'http://localhost:3101', target: 'http://localhost:3105'}]
-  })
-  yield graph.startConnector('mia2', 4105, {
-    edges: [{source: 'http://localhost:3105', target: 'http://localhost:3106'}]
-  })
-  yield graph.startConnector('mike2', 4106, {
-    edges: [{source: 'http://localhost:3106', target: 'http://localhost:3107'}]
-  })
-
-  yield services.startNotary('notary2_1', 6101, {
-    secretKey: notarySecretKey,
-    publicKey: notaryPublicKey
-  })
-
-  yield graph.startReceiver(7101, {secret: receiverSecret})
-})
-
-beforeEach(function * () { yield graph.setupAccounts() })
-
-describe('send universal payment', function () {
-  it('scale: high → low; by source amount', function * () {
-    const receiverId = 'universal-0001'
-    yield services.sendPayment({
-      sourceAccount: 'http://localhost:3101/accounts/alice',
-      sourcePassword: 'alice',
-      destinationAccount: 'http://localhost:3102/accounts/bob',
-      sourceAmount: '4.9999',
-      receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
-      destinationMemo: { receiverId }
+    yield graph.startConnector('mark2', 4101, {
+      edges: [{source: 'http://localhost:3101', target: 'http://localhost:3102'}]
     })
-    yield Promise.delay(2000)
-    // Alice should have:
-    //    100      USD
-    //  -   4.9999 USD (sent to Bob)
-    //  ==============
-    //     95.0001 USD
-    yield services.assertBalance('http://localhost:3101', 'alice', '95.0001')
-    yield services.assertBalance('http://localhost:3101', 'mark2', '1004.9999')
 
-    // Bob should have:
-    //    100       USD
-    //  +   4.9999  USD (money from Alice)
-    //  -   0.0099‥ USD (mark: spread/fee)
-    //  -   0.0049‥ USD (mark: quoted connector slippage)
-    //  -   0.01    USD (mark: 1/10^destination_scale)
-    //  ===============
-    //    104.9751  USD
-    //    104.97    USD (round down)
-    yield services.assertBalance('http://localhost:3102', 'bob', '104.97')
-    yield services.assertBalance('http://localhost:3102', 'mark2', '995.03')
-    yield services.assertZeroHold()
+    yield graph.startConnector('mary2', 4102, {
+      edges: [{source: 'http://localhost:3101', target: 'http://localhost:3103'}],
+      slippage: '0'
+    })
+
+    yield graph.startConnector('martin2', 4103, {
+      edges: [{source: 'http://localhost:3101', target: 'http://localhost:3104'}],
+      fxSpread: '0.5'
+    })
+
+    yield graph.startConnector('millie2', 4104, {
+      edges: [{source: 'http://localhost:3101', target: 'http://localhost:3105'}]
+    })
+    yield graph.startConnector('mia2', 4105, {
+      edges: [{source: 'http://localhost:3105', target: 'http://localhost:3106'}]
+    })
+    yield graph.startConnector('mike2', 4106, {
+      edges: [{source: 'http://localhost:3106', target: 'http://localhost:3107'}]
+    })
+
+    yield services.startNotary('notary2_1', 6101, {
+      secretKey: notarySecretKey,
+      publicKey: notaryPublicKey
+    })
+
+    yield graph.startReceiver(7101, {secret: receiverSecret})
   })
 
-  it('scale: low → high', function * () {
-    const receiverId = 'universal-0002'
-    yield services.sendPayment({
-      sourceAccount: 'http://localhost:3102/accounts/alice',
-      sourcePassword: 'alice',
-      destinationAccount: 'http://localhost:3101/accounts/bob',
-      sourceAmount: '4.99',
-      receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
-      destinationMemo: { receiverId }
+  beforeEach(function * () { yield graph.setupAccounts() })
+
+  describe('send universal payment', function () {
+    it('scale: high → low; by source amount', function * () {
+      const receiverId = 'universal-0001'
+      yield services.sendPayment({
+        sourceAccount: 'http://localhost:3101/accounts/alice',
+        sourcePassword: 'alice',
+        destinationAccount: 'http://localhost:3102/accounts/bob',
+        sourceAmount: '4.9999',
+        receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
+        destinationMemo: { receiverId }
+      })
+      yield Promise.delay(2000)
+      // Alice should have:
+      //    100      USD
+      //  -   4.9999 USD (sent to Bob)
+      //  ==============
+      //     95.0001 USD
+      yield services.assertBalance('http://localhost:3101', 'alice', '95.0001')
+      yield services.assertBalance('http://localhost:3101', 'mark2', '1004.9999')
+
+      // Bob should have:
+      //    100       USD
+      //  +   4.9999  USD (money from Alice)
+      //  -   0.0099‥ USD (mark: spread/fee)
+      //  -   0.0049‥ USD (mark: quoted connector slippage)
+      //  -   0.01    USD (mark: 1/10^destination_scale)
+      //  ===============
+      //    104.9751  USD
+      //    104.97    USD (round down)
+      yield services.assertBalance('http://localhost:3102', 'bob', '104.97')
+      yield services.assertBalance('http://localhost:3102', 'mark2', '995.03')
+      yield services.assertZeroHold()
     })
-    yield Promise.delay(2000)
-    // Alice should have:
-    //    100      USD
-    //  -   4.99   USD (sent to Bob)
-    //  ==============
-    //     95.01   USD
-    yield services.assertBalance('http://localhost:3102', 'alice', '95.01')
-    yield services.assertBalance('http://localhost:3102', 'mark2', '1004.99')
 
-    // Bob should have:
-    //    100       USD
-    //  +   4.99    USD (money from Alice)
-    //  -   0.00998 USD (mark: spread/fee)
-    //  -   0.00499 USD (mark: quoted connector slippage)
-    //  -   0.0001  USD (mark: 1/10^destination_scale)
-    //  ===============
-    //    104.97493 USD
-    //    104.9749  USD (round down)
-    yield services.assertBalance('http://localhost:3101', 'bob', '104.9749')
-    yield services.assertBalance('http://localhost:3101', 'mark2', '995.0251')
-    yield services.assertZeroHold()
-  })
+    it('scale: low → high', function * () {
+      const receiverId = 'universal-0002'
+      yield services.sendPayment({
+        sourceAccount: 'http://localhost:3102/accounts/alice',
+        sourcePassword: 'alice',
+        destinationAccount: 'http://localhost:3101/accounts/bob',
+        sourceAmount: '4.99',
+        receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
+        destinationMemo: { receiverId }
+      })
+      yield Promise.delay(2000)
+      // Alice should have:
+      //    100      USD
+      //  -   4.99   USD (sent to Bob)
+      //  ==============
+      //     95.01   USD
+      yield services.assertBalance('http://localhost:3102', 'alice', '95.01')
+      yield services.assertBalance('http://localhost:3102', 'mark2', '1004.99')
 
-  it('zero slippage', function * () {
-    const receiverId = 'universal-0003'
-    yield services.sendPayment({
-      sourceAccount: 'http://localhost:3101/accounts/alice',
-      sourcePassword: 'alice',
-      destinationAccount: 'http://localhost:3103/accounts/bob',
-      sourceAmount: '5',
-      receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
-      destinationMemo: { receiverId }
+      // Bob should have:
+      //    100       USD
+      //  +   4.99    USD (money from Alice)
+      //  -   0.00998 USD (mark: spread/fee)
+      //  -   0.00499 USD (mark: quoted connector slippage)
+      //  -   0.0001  USD (mark: 1/10^destination_scale)
+      //  ===============
+      //    104.97493 USD
+      //    104.9749  USD (round down)
+      yield services.assertBalance('http://localhost:3101', 'bob', '104.9749')
+      yield services.assertBalance('http://localhost:3101', 'mark2', '995.0251')
+      yield services.assertZeroHold()
     })
-    yield Promise.delay(2000)
-    // Alice should have:
-    //    100      USD
-    //  -   5      USD (sent to Bob)
-    //  ==============
-    //     95      USD
-    yield services.assertBalance('http://localhost:3101', 'alice', '95')
-    yield services.assertBalance('http://localhost:3101', 'mary2', '1005')
 
-    // Bob should have:
-    //    100      USD
-    //  +   5      USD (money from Alice)
-    //  -   0.01   USD (mary: spread/fee)
-    //  -   0      USD (mary: quoted connector slippage)
-    //  -   0.0001 USD (mary: 1/10^destination_scale)
-    //  ==============
-    //    104.9899 USD
-    yield services.assertBalance('http://localhost:3103', 'bob', '104.9899')
-    yield services.assertBalance('http://localhost:3103', 'mary2', '995.0101')
-    yield services.assertZeroHold()
-  })
+    it('zero slippage', function * () {
+      const receiverId = 'universal-0003'
+      yield services.sendPayment({
+        sourceAccount: 'http://localhost:3101/accounts/alice',
+        sourcePassword: 'alice',
+        destinationAccount: 'http://localhost:3103/accounts/bob',
+        sourceAmount: '5',
+        receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
+        destinationMemo: { receiverId }
+      })
+      yield Promise.delay(2000)
+      // Alice should have:
+      //    100      USD
+      //  -   5      USD (sent to Bob)
+      //  ==============
+      //     95      USD
+      yield services.assertBalance('http://localhost:3101', 'alice', '95')
+      yield services.assertBalance('http://localhost:3101', 'mary2', '1005')
 
-  it('high spread', function * () {
-    const receiverId = 'universal-0004'
-    yield services.sendPayment({
-      sourceAccount: 'http://localhost:3101/accounts/alice',
-      sourcePassword: 'alice',
-      destinationAccount: 'http://localhost:3104/accounts/bob',
-      sourceAmount: '5',
-      receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
-      destinationMemo: { receiverId }
+      // Bob should have:
+      //    100      USD
+      //  +   5      USD (money from Alice)
+      //  -   0.01   USD (mary: spread/fee)
+      //  -   0      USD (mary: quoted connector slippage)
+      //  -   0.0001 USD (mary: 1/10^destination_scale)
+      //  ==============
+      //    104.9899 USD
+      yield services.assertBalance('http://localhost:3103', 'bob', '104.9899')
+      yield services.assertBalance('http://localhost:3103', 'mary2', '995.0101')
+      yield services.assertZeroHold()
     })
-    yield Promise.delay(2000)
-    // Alice should have:
-    //    100      USD
-    //  -   5      USD (sent to Bob)
-    //  ==============
-    //     95      USD
-    yield services.assertBalance('http://localhost:3101', 'alice', '95')
-    yield services.assertBalance('http://localhost:3101', 'martin2', '1005')
 
-    // Bob should have:
-    //    100      USD
-    //  +   5      USD (money from Alice)
-    //  -   2.5    USD (martin: spread/fee)
-    //  -   0.0025 USD (martin: quoted connector slippage; (5 - 2.5) * 0.001)
-    //  -   0.0001 USD (martin: 1/10^destination_scale)
-    //  ==============
-    //    102.4974 USD
-    yield services.assertBalance('http://localhost:3104', 'bob', '102.4974')
-    yield services.assertBalance('http://localhost:3104', 'martin2', '997.5026')
-    yield services.assertZeroHold()
-  })
+    it('high spread', function * () {
+      const receiverId = 'universal-0004'
+      yield services.sendPayment({
+        sourceAccount: 'http://localhost:3101/accounts/alice',
+        sourcePassword: 'alice',
+        destinationAccount: 'http://localhost:3104/accounts/bob',
+        sourceAmount: '5',
+        receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
+        destinationMemo: { receiverId }
+      })
+      yield Promise.delay(2000)
+      // Alice should have:
+      //    100      USD
+      //  -   5      USD (sent to Bob)
+      //  ==============
+      //     95      USD
+      yield services.assertBalance('http://localhost:3101', 'alice', '95')
+      yield services.assertBalance('http://localhost:3101', 'martin2', '1005')
 
-  it('many hops', function * () {
-    // Send payment 1→5→6→7
-    const receiverId = 'universal-0005'
-    yield services.sendPayment({
-      sourceAccount: 'http://localhost:3101/accounts/alice',
-      sourcePassword: 'alice',
-      destinationAccount: 'http://localhost:3107/accounts/bob',
-      sourceAmount: '4.9999',
-      receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
-      destinationMemo: { receiverId }
+      // Bob should have:
+      //    100      USD
+      //  +   5      USD (money from Alice)
+      //  -   2.5    USD (martin: spread/fee)
+      //  -   0.0025 USD (martin: quoted connector slippage; (5 - 2.5) * 0.001)
+      //  -   0.0001 USD (martin: 1/10^destination_scale)
+      //  ==============
+      //    102.4974 USD
+      yield services.assertBalance('http://localhost:3104', 'bob', '102.4974')
+      yield services.assertBalance('http://localhost:3104', 'martin2', '997.5026')
+      yield services.assertZeroHold()
     })
-    yield Promise.delay(2000)
-    // Alice should have:
-    //    100      USD
-    //  -   4.9999 USD (sent to Bob)
-    //  ==============
-    //     95.0001 USD
-    yield services.assertBalance('http://localhost:3101', 'alice', '95.0001')
-    yield services.assertBalance('http://localhost:3101', 'millie2', '1004.9999')
 
-    // Mia should have:
-    //   1000         USD
-    //  +   4.9999    USD (sent from Millie)
-    //  -   0.0099998 USD (millie: spread/fee 1→5; 4.9999*0.002)
-    //  -   0.0001    USD (millie: 1/10^ledger5_scale)
-    //  =================
-    //   1004.9898002 USD
-    //   1004.9899    USD (round destination up)
-    yield services.assertBalance('http://localhost:3105', 'millie2', '995.0101')
-    yield services.assertBalance('http://localhost:3105', 'mia2', '1004.9899')
+    it('many hops', function * () {
+      // Send payment 1→5→6→7
+      const receiverId = 'universal-0005'
+      yield services.sendPayment({
+        sourceAccount: 'http://localhost:3101/accounts/alice',
+        sourcePassword: 'alice',
+        destinationAccount: 'http://localhost:3107/accounts/bob',
+        sourceAmount: '4.9999',
+        receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
+        destinationMemo: { receiverId }
+      })
+      yield Promise.delay(2000)
+      // Alice should have:
+      //    100      USD
+      //  -   4.9999 USD (sent to Bob)
+      //  ==============
+      //     95.0001 USD
+      yield services.assertBalance('http://localhost:3101', 'alice', '95.0001')
+      yield services.assertBalance('http://localhost:3101', 'millie2', '1004.9999')
 
-    // Mark should have:
-    //   1000           USD
-    //  +   4.9899      USD (sent from Mia)
-    //  -   0.009979799 USD (mia: spread/fee 5→6; 4.9899*0.002)
-    //  -   0.0001      USD (mia: 1/10^ledger6_scale)
-    //  ===================
-    //   1004.9798202   USD
-    //   1004.9799      USD (round destination up)
-    yield services.assertBalance('http://localhost:3106', 'mia2', '995.0201')
-    yield services.assertBalance('http://localhost:3106', 'mike2', '1004.9799')
+      // Mia should have:
+      //   1000         USD
+      //  +   4.9999    USD (sent from Millie)
+      //  -   0.0099998 USD (millie: spread/fee 1→5; 4.9999*0.002)
+      //  -   0.0001    USD (millie: 1/10^ledger5_scale)
+      //  =================
+      //   1004.9898002 USD
+      //   1004.9899    USD (round destination up)
+      yield services.assertBalance('http://localhost:3105', 'millie2', '995.0101')
+      yield services.assertBalance('http://localhost:3105', 'mia2', '1004.9899')
 
-    // Bob should have:
-    //    100         USD
-    //  +   4.9999    USD (original amount from Alice)
-    //  ×   0.998         (millie: spread/fee 1→5; 0.998 = 1 - 0.002)
-    //  -   0.0001    USD (millie: 1/10^ledger5_scale)
-    //  ×   0.998         (mia: spread/fee 5→6)
-    //  -   0.0001    USD (mia: 1/10^ledger6_scale)
-    //  ×   0.998         (mike: spread/fee 6→7)
-    //  -   0.0001    USD (mike: 1/10^ledger7_scale)
-    //  ×   0.999         (millie: quoted connector slippage; 0.999 = 1 - 0.001)
-    //  =================
-    //    104.964691‥ USD
-    //    104.9646    USD (round destination down)
-    yield services.assertBalance('http://localhost:3107', 'bob', '104.9646')
-    yield services.assertBalance('http://localhost:3107', 'mike2', '995.0354')
-    yield services.assertZeroHold()
+      // Mark should have:
+      //   1000           USD
+      //  +   4.9899      USD (sent from Mia)
+      //  -   0.009979799 USD (mia: spread/fee 5→6; 4.9899*0.002)
+      //  -   0.0001      USD (mia: 1/10^ledger6_scale)
+      //  ===================
+      //   1004.9798202   USD
+      //   1004.9799      USD (round destination up)
+      yield services.assertBalance('http://localhost:3106', 'mia2', '995.0201')
+      yield services.assertBalance('http://localhost:3106', 'mike2', '1004.9799')
+
+      // Bob should have:
+      //    100         USD
+      //  +   4.9999    USD (original amount from Alice)
+      //  ×   0.998         (millie: spread/fee 1→5; 0.998 = 1 - 0.002)
+      //  -   0.0001    USD (millie: 1/10^ledger5_scale)
+      //  ×   0.998         (mia: spread/fee 5→6)
+      //  -   0.0001    USD (mia: 1/10^ledger6_scale)
+      //  ×   0.998         (mike: spread/fee 6→7)
+      //  -   0.0001    USD (mike: 1/10^ledger7_scale)
+      //  ×   0.999         (millie: quoted connector slippage; 0.999 = 1 - 0.001)
+      //  =================
+      //    104.964691‥ USD
+      //    104.9646    USD (round destination down)
+      yield services.assertBalance('http://localhost:3107', 'bob', '104.9646')
+      yield services.assertBalance('http://localhost:3107', 'mike2', '995.0354')
+      yield services.assertZeroHold()
+    })
   })
 })

--- a/src/tests/advanced.js
+++ b/src/tests/advanced.js
@@ -21,6 +21,8 @@ before(function * () {
   yield graph.startLedger('ledger2_6', 3106, {scale: 4})
   yield graph.startLedger('ledger2_7', 3107, {scale: 4})
 
+  yield graph.setupAccounts()
+
   yield graph.startConnector('mark2', 4101, {
     edges: [{source: 'http://localhost:3101', target: 'http://localhost:3102'}]
   })

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -12,340 +12,342 @@ const receiverSecret = 'O8Y6+6bJgl2i285yCeC/Wigi6P6TJ4C78tdASqDOR9g='
 const services = new ServiceManager(process.cwd())
 const graph = new ServiceGraph(services)
 
-before(function * () {
-  yield graph.startLedger('ledger1', 3001, {})
-  yield graph.startLedger('ledger2', 3002, {})
-  yield graph.startLedger('ledger3', 3003, {})
+describe('Basic', function () {
+  before(function * () {
+    yield graph.startLedger('ledger1', 3001, {})
+    yield graph.startLedger('ledger2', 3002, {})
+    yield graph.startLedger('ledger3', 3003, {})
 
-  yield graph.setupAccounts()
+    yield graph.setupAccounts()
 
-  yield graph.startConnector('mark', 4001, {
-    edges: [
-      {source: 'http://localhost:3001', target: 'http://localhost:3002'}
-    ]
-  })
-
-  yield graph.startConnector('mary', 4002, {
-    edges: [
-      {source: 'http://localhost:3002', target: 'http://localhost:3003'}
-    ]
-  })
-
-  yield services.startNotary('notary1', 6001, {
-    secretKey: notarySecretKey,
-    publicKey: notaryPublicKey
-  })
-
-  yield graph.startReceiver(7001, {secret: receiverSecret})
-})
-
-beforeEach(function * () { yield graph.setupAccounts() })
-
-describe('account creation', function () {
-  it('won\'t allow in incorrect admin password', function * () {
-    try {
-      yield services.updateAccount('http://localhost:3001', 'someone', {adminPass: 'wrong'})
-    } catch (err) {
-      assert.equal(err.status, 403)
-      return
-    }
-    assert(false)
-  })
-})
-
-describe('checking balances', function () {
-  it('initializes with the correct amounts', function * () {
-    yield services.assertBalance('http://localhost:3001', 'alice', '100')
-    yield services.assertBalance('http://localhost:3002', 'bob', '100')
-    // Connectors
-    yield services.assertBalance('http://localhost:3001', 'hold', '0')
-    yield services.assertBalance('http://localhost:3002', 'hold', '0')
-    yield services.assertBalance('http://localhost:3003', 'hold', '0')
-    yield services.assertBalance('http://localhost:3001', 'mark', '1000')
-    yield services.assertBalance('http://localhost:3002', 'mark', '1000')
-    yield services.assertBalance('http://localhost:3002', 'mary', '1000')
-    yield services.assertBalance('http://localhost:3003', 'mary', '1000')
-  })
-
-  it('won\'t allow an incorrect admin password', function * () {
-    try {
-      yield services.getBalance('http://localhost:3001', 'alice', {adminPass: 'wrong'})
-    } catch (err) {
-      assert.equal(err.status, 403)
-      return
-    }
-    assert(false)
-  })
-})
-
-describe('send universal payment', function () {
-  it('transfers the funds (by destination amount)', function * () {
-    const receiverId = 'universal-0001'
-    yield services.sendPayment({
-      sourceAccount: 'http://localhost:3001/accounts/alice',
-      sourcePassword: 'alice',
-      destinationAccount: 'http://localhost:3002/accounts/bob',
-      destinationAmount: '5',
-      receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
-      destinationMemo: { receiverId }
+    yield graph.startConnector('mark', 4001, {
+      edges: [
+        {source: 'http://localhost:3001', target: 'http://localhost:3002'}
+      ]
     })
-    yield Promise.delay(2000)
-    // Alice should have:
-    //    100      USD
-    //  -   5      USD (sent to Bob)
-    //  -   0.01   USD (connector spread/fee)
-    //  -   0.0001 USD (connector rounding in its favor)
-    //  -   0.005  USD (mark: quoted connector slippage)
-    //  -   0.0001 USD (mark: 1/10^scale)
-    //  ==============
-    //     94.9848 USD
-    yield services.assertBalance('http://localhost:3001', 'alice', '94.9848')
-    yield services.assertBalance('http://localhost:3001', 'mark', '1005.0152')
 
-    // Bob should have:
-    //    100      USD
-    //  +   5      USD (money from Alice)
-    //  ==============
-    //    105      USD
-    yield services.assertBalance('http://localhost:3002', 'bob', '105')
-    yield services.assertBalance('http://localhost:3002', 'mark', '995')
-    yield services.assertZeroHold()
-  })
-
-  it('transfers the funds (by source amount)', function * () {
-    const receiverId = 'universal-0002'
-    yield services.sendPayment({
-      sourceAccount: 'http://localhost:3001/accounts/alice',
-      sourcePassword: 'alice',
-      destinationAccount: 'http://localhost:3002/accounts/bob',
-      sourceAmount: '5',
-      receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
-      destinationMemo: { receiverId }
+    yield graph.startConnector('mary', 4002, {
+      edges: [
+        {source: 'http://localhost:3002', target: 'http://localhost:3003'}
+      ]
     })
-    yield Promise.delay(2000)
-    // Alice should have:
-    //    100      USD
-    //  -   5      USD (sent to Bob)
-    //  ==============
-    //     95      USD
-    yield services.assertBalance('http://localhost:3001', 'alice', '95')
-    yield services.assertBalance('http://localhost:3001', 'mark', '1005')
 
-    // Bob should have:
-    //    100      USD
-    //  +   5      USD (money from Alice)
-    //  -   0.01   USD (connector spread/fee)
-    //  -   0.005  USD (mark: quoted connector slippage)
-    //  -   0.0001 USD (mark: 1/10^scale)
-    //  ==============
-    //    104.9849  USD
-    yield services.assertBalance('http://localhost:3002', 'bob', '104.9849')
-    yield services.assertBalance('http://localhost:3002', 'mark', '995.0151')
-    yield services.assertZeroHold()
+    yield services.startNotary('notary1', 6001, {
+      secretKey: notarySecretKey,
+      publicKey: notaryPublicKey
+    })
+
+    yield graph.startReceiver(7001, {secret: receiverSecret})
   })
 
-  it('fails when there are insufficient source funds', function * () {
-    const receiverId = 'universal-0003'
-    let err
-    try {
+  beforeEach(function * () { yield graph.setupAccounts() })
+
+  describe('account creation', function () {
+    it('won\'t allow in incorrect admin password', function * () {
+      try {
+        yield services.updateAccount('http://localhost:3001', 'someone', {adminPass: 'wrong'})
+      } catch (err) {
+        assert.equal(err.status, 403)
+        return
+      }
+      assert(false)
+    })
+  })
+
+  describe('checking balances', function () {
+    it('initializes with the correct amounts', function * () {
+      yield services.assertBalance('http://localhost:3001', 'alice', '100')
+      yield services.assertBalance('http://localhost:3002', 'bob', '100')
+      // Connectors
+      yield services.assertBalance('http://localhost:3001', 'hold', '0')
+      yield services.assertBalance('http://localhost:3002', 'hold', '0')
+      yield services.assertBalance('http://localhost:3003', 'hold', '0')
+      yield services.assertBalance('http://localhost:3001', 'mark', '1000')
+      yield services.assertBalance('http://localhost:3002', 'mark', '1000')
+      yield services.assertBalance('http://localhost:3002', 'mary', '1000')
+      yield services.assertBalance('http://localhost:3003', 'mary', '1000')
+    })
+
+    it('won\'t allow an incorrect admin password', function * () {
+      try {
+        yield services.getBalance('http://localhost:3001', 'alice', {adminPass: 'wrong'})
+      } catch (err) {
+        assert.equal(err.status, 403)
+        return
+      }
+      assert(false)
+    })
+  })
+
+  describe('send universal payment', function () {
+    it('transfers the funds (by destination amount)', function * () {
+      const receiverId = 'universal-0001'
       yield services.sendPayment({
         sourceAccount: 'http://localhost:3001/accounts/alice',
         sourcePassword: 'alice',
         destinationAccount: 'http://localhost:3002/accounts/bob',
-        destinationAmount: '500',
+        destinationAmount: '5',
         receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
         destinationMemo: { receiverId }
       })
-    } catch (_err) { err = _err }
-    assert.equal(err.status, 422)
-    assert.deepEqual(err.response.body, {
-      id: 'InsufficientFundsError',
-      message: 'Sender has insufficient funds.',
-      owner: 'alice'
-    })
-    yield Promise.delay(2000)
+      yield Promise.delay(2000)
+      // Alice should have:
+      //    100      USD
+      //  -   5      USD (sent to Bob)
+      //  -   0.01   USD (connector spread/fee)
+      //  -   0.0001 USD (connector rounding in its favor)
+      //  -   0.005  USD (mark: quoted connector slippage)
+      //  -   0.0001 USD (mark: 1/10^scale)
+      //  ==============
+      //     94.9848 USD
+      yield services.assertBalance('http://localhost:3001', 'alice', '94.9848')
+      yield services.assertBalance('http://localhost:3001', 'mark', '1005.0152')
 
-    // No change to balances:
-    yield services.assertBalance('http://localhost:3001', 'alice', '100')
-    yield services.assertBalance('http://localhost:3001', 'mark', '1000')
-    yield services.assertBalance('http://localhost:3002', 'bob', '100')
-    yield services.assertBalance('http://localhost:3002', 'mark', '1000')
-    yield services.assertZeroHold()
+      // Bob should have:
+      //    100      USD
+      //  +   5      USD (money from Alice)
+      //  ==============
+      //    105      USD
+      yield services.assertBalance('http://localhost:3002', 'bob', '105')
+      yield services.assertBalance('http://localhost:3002', 'mark', '995')
+      yield services.assertZeroHold()
+    })
+
+    it('transfers the funds (by source amount)', function * () {
+      const receiverId = 'universal-0002'
+      yield services.sendPayment({
+        sourceAccount: 'http://localhost:3001/accounts/alice',
+        sourcePassword: 'alice',
+        destinationAccount: 'http://localhost:3002/accounts/bob',
+        sourceAmount: '5',
+        receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
+        destinationMemo: { receiverId }
+      })
+      yield Promise.delay(2000)
+      // Alice should have:
+      //    100      USD
+      //  -   5      USD (sent to Bob)
+      //  ==============
+      //     95      USD
+      yield services.assertBalance('http://localhost:3001', 'alice', '95')
+      yield services.assertBalance('http://localhost:3001', 'mark', '1005')
+
+      // Bob should have:
+      //    100      USD
+      //  +   5      USD (money from Alice)
+      //  -   0.01   USD (connector spread/fee)
+      //  -   0.005  USD (mark: quoted connector slippage)
+      //  -   0.0001 USD (mark: 1/10^scale)
+      //  ==============
+      //    104.9849  USD
+      yield services.assertBalance('http://localhost:3002', 'bob', '104.9849')
+      yield services.assertBalance('http://localhost:3002', 'mark', '995.0151')
+      yield services.assertZeroHold()
+    })
+
+    it('fails when there are insufficient source funds', function * () {
+      const receiverId = 'universal-0003'
+      let err
+      try {
+        yield services.sendPayment({
+          sourceAccount: 'http://localhost:3001/accounts/alice',
+          sourcePassword: 'alice',
+          destinationAccount: 'http://localhost:3002/accounts/bob',
+          destinationAmount: '500',
+          receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
+          destinationMemo: { receiverId }
+        })
+      } catch (_err) { err = _err }
+      assert.equal(err.status, 422)
+      assert.deepEqual(err.response.body, {
+        id: 'InsufficientFundsError',
+        message: 'Sender has insufficient funds.',
+        owner: 'alice'
+      })
+      yield Promise.delay(2000)
+
+      // No change to balances:
+      yield services.assertBalance('http://localhost:3001', 'alice', '100')
+      yield services.assertBalance('http://localhost:3001', 'mark', '1000')
+      yield services.assertBalance('http://localhost:3002', 'bob', '100')
+      yield services.assertBalance('http://localhost:3002', 'mark', '1000')
+      yield services.assertZeroHold()
+    })
+
+    it('transfers a payment with 3 steps', function * () {
+      const receiverId = 'universal-0004'
+      yield services.sendPayment({
+        sourceAccount: 'http://localhost:3001/accounts/alice',
+        sourcePassword: 'alice',
+        destinationAccount: 'http://localhost:3003/accounts/bob',
+        destinationAmount: '5',
+        receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
+        destinationMemo: { receiverId }
+      })
+      yield Promise.delay(2000)
+
+      // Alice should have:
+      //    100      USD
+      //  -   5      USD (sent to Bob)
+      //  -   0.01   USD (mary: connector spread/fee)
+      //  -   0.0001 USD (mary: 1/10^scale)
+      //  -   0.01   USD (mark: connector spread/fee)
+      //  -   0.0001 USD (mark: 1/10^scale)
+      //  -   0.005  USD (mark: quoted connector slippage)
+      //  -   0.0001 USD (mark: round source amount up)
+      //  ==============
+      //     94.9747 USD
+      yield services.assertBalance('http://localhost:3001', 'alice', '94.9747')
+      yield services.assertBalance('http://localhost:3001', 'mark', '1005.0253')
+
+      yield services.assertBalance('http://localhost:3002', 'mark', '994.9848')
+      yield services.assertBalance('http://localhost:3002', 'mary', '1005.0152')
+
+      // Bob should have:
+      //    100      USD
+      //  +   5      USD (money from Alice)
+      //  ==============
+      //    105      USD
+      yield services.assertBalance('http://localhost:3003', 'bob', '105')
+      yield services.assertBalance('http://localhost:3003', 'mary', '995')
+      yield services.assertZeroHold()
+    })
+
+    it('transfers a small amount (by destination amount)', function * () {
+      const receiverId = 'universal-0005'
+      yield services.sendPayment({
+        sourceAccount: 'http://localhost:3001/accounts/alice',
+        sourcePassword: 'alice',
+        destinationAccount: 'http://localhost:3003/accounts/bob',
+        destinationAmount: '0.01',
+        receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
+        destinationMemo: { receiverId }
+      })
+      yield Promise.delay(2000)
+      // Alice should have:
+      //    100      USD
+      //  -   0.01   USD (sent to Bob)
+      //  -   0.00002 USD (mary: connector spread/fee)
+      //  -   0.0001  USD (mary: 1/10^scale)
+      //  -   0.00002 USD (mark: connector spread/fee)
+      //  -   0.0001  USD (mark: 1/10^scale)
+      //  -   0.00001 USD (mark: quoted connector slippage)
+      //  -   0.00005 USD (mark: round source amount up)
+      //  ===============
+      //     99.9897  USD
+      yield services.assertBalance('http://localhost:3001', 'alice', '99.9897')
+      yield services.assertBalance('http://localhost:3001', 'mark', '1000.0103')
+
+      yield services.assertBalance('http://localhost:3002', 'mark', '999.9898')
+      yield services.assertBalance('http://localhost:3002', 'mary', '1000.0102')
+
+      // Bob should have:
+      //    100      USD
+      //  +   0.01   USD (money from Alice)
+      //  ==============
+      //    100.01   USD
+      yield services.assertBalance('http://localhost:3003', 'bob', '100.01')
+      yield services.assertBalance('http://localhost:3003', 'mary', '999.99')
+      yield services.assertZeroHold()
+    })
+
+    it('transfers a small amount (by source amount)', function * () {
+      const receiverId = 'universal-0005'
+      yield services.sendPayment({
+        sourceAccount: 'http://localhost:3001/accounts/alice',
+        sourcePassword: 'alice',
+        destinationAccount: 'http://localhost:3003/accounts/bob',
+        sourceAmount: '0.01',
+        receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
+        destinationMemo: { receiverId }
+      })
+      yield Promise.delay(2000)
+      // Alice should have:
+      //    100      USD
+      //  -   0.01   USD (sent to Bob)
+      //  ==============
+      //     99.99   USD
+      yield services.assertBalance('http://localhost:3001', 'alice', '99.99')
+      yield services.assertBalance('http://localhost:3001', 'mark', '1000.01')
+
+      yield services.assertBalance('http://localhost:3002', 'mark', '999.9901')
+      yield services.assertBalance('http://localhost:3002', 'mary', '1000.0099')
+
+      // Bob should have:
+      //    100       USD
+      //  +   0.01    USD (money from Alice)
+      //  -   0.00002 USD (mary: connector spread/fee)
+      //  -   0.0001  USD (mary: 1/10^scale)
+      //  -   0.00002 USD (mark: connector spread/fee)
+      //  -   0.0001  USD (mark: 1/10^scale)
+      //  -   0.00001 USD (mark: quoted connector slippage)
+      //  -   0.00005 USD (mark: round destination amount down)
+      //  ==============
+      //    100.0097  USD
+      yield services.assertBalance('http://localhost:3003', 'Bob', '100.0097')
+      yield services.assertBalance('http://localhost:3003', 'mary', '999.9903')
+      yield services.assertZeroHold()
+    })
   })
 
-  it('transfers a payment with 3 steps', function * () {
-    const receiverId = 'universal-0004'
-    yield services.sendPayment({
-      sourceAccount: 'http://localhost:3001/accounts/alice',
-      sourcePassword: 'alice',
-      destinationAccount: 'http://localhost:3003/accounts/bob',
-      destinationAmount: '5',
-      receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
-      destinationMemo: { receiverId }
+  describe('send atomic payment', function () {
+    it('transfers the funds', function * () {
+      const receiverId = 'atomic-0001'
+      yield services.sendPayment({
+        sourceAccount: 'http://localhost:3001/accounts/alice',
+        sourcePassword: 'alice',
+        destinationAccount: 'http://localhost:3002/accounts/bob',
+        destinationAmount: '5',
+        notary: 'http://localhost:6001',
+        notaryPublicKey,
+        receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
+        destinationMemo: { receiverId }
+      })
+      yield Promise.delay(2000)
+      // Alice should have:
+      //    100      USD
+      //  -   5      USD (sent to Bob)
+      //  -   0.01   USD (connector spread/fee)
+      //  -   0.0001 USD (connector rounding in its favor)
+      //  -   0.0001 USD (mark: 1/10^scale)
+      //  -   0.005  USD (mark: quoted connector slippage)
+      //  ==============
+      //     94.9848 USD
+      yield services.assertBalance('http://localhost:3001', 'alice', '94.9848')
+      yield services.assertBalance('http://localhost:3001', 'mark', '1005.0152')
+
+      // Bob should have:
+      //    100      USD
+      //  +   5      USD (money from Alice)
+      //  ==============
+      //    105      USD
+      yield services.assertBalance('http://localhost:3002', 'bob', '105')
+      yield services.assertBalance('http://localhost:3002', 'mark', '995')
+      yield services.assertZeroHold()
     })
-    yield Promise.delay(2000)
-
-    // Alice should have:
-    //    100      USD
-    //  -   5      USD (sent to Bob)
-    //  -   0.01   USD (mary: connector spread/fee)
-    //  -   0.0001 USD (mary: 1/10^scale)
-    //  -   0.01   USD (mark: connector spread/fee)
-    //  -   0.0001 USD (mark: 1/10^scale)
-    //  -   0.005  USD (mark: quoted connector slippage)
-    //  -   0.0001 USD (mark: round source amount up)
-    //  ==============
-    //     94.9747 USD
-    yield services.assertBalance('http://localhost:3001', 'alice', '94.9747')
-    yield services.assertBalance('http://localhost:3001', 'mark', '1005.0253')
-
-    yield services.assertBalance('http://localhost:3002', 'mark', '994.9848')
-    yield services.assertBalance('http://localhost:3002', 'mary', '1005.0152')
-
-    // Bob should have:
-    //    100      USD
-    //  +   5      USD (money from Alice)
-    //  ==============
-    //    105      USD
-    yield services.assertBalance('http://localhost:3003', 'bob', '105')
-    yield services.assertBalance('http://localhost:3003', 'mary', '995')
-    yield services.assertZeroHold()
   })
 
-  it('transfers a small amount (by destination amount)', function * () {
-    const receiverId = 'universal-0005'
-    yield services.sendPayment({
-      sourceAccount: 'http://localhost:3001/accounts/alice',
-      sourcePassword: 'alice',
-      destinationAccount: 'http://localhost:3003/accounts/bob',
-      destinationAmount: '0.01',
-      receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
-      destinationMemo: { receiverId }
+  describe('send same-ledger payment', function () {
+    it('transfers the funds', function * () {
+      const receiverId = 'same-ledger-0001'
+      yield services.sendPayment({
+        sourceAccount: 'http://localhost:3001/accounts/alice',
+        sourcePassword: 'alice',
+        destinationAccount: 'http://localhost:3001/accounts/bob',
+        destinationAmount: '5',
+        receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
+        destinationMemo: { receiverId }
+      })
+      yield Promise.delay(2000)
+      // Alice should have:
+      //    100      USD
+      //  -   5      USD (sent to Bob)
+      //  ==============
+      //     95      USD
+      yield services.assertBalance('http://localhost:3001', 'alice', '95')
+      yield services.assertBalance('http://localhost:3001', 'bob', '105')
+      yield services.assertBalance('http://localhost:3001', 'mark', '1000')
+      yield services.assertZeroHold()
     })
-    yield Promise.delay(2000)
-    // Alice should have:
-    //    100      USD
-    //  -   0.01   USD (sent to Bob)
-    //  -   0.00002 USD (mary: connector spread/fee)
-    //  -   0.0001  USD (mary: 1/10^scale)
-    //  -   0.00002 USD (mark: connector spread/fee)
-    //  -   0.0001  USD (mark: 1/10^scale)
-    //  -   0.00001 USD (mark: quoted connector slippage)
-    //  -   0.00005 USD (mark: round source amount up)
-    //  ===============
-    //     99.9897  USD
-    yield services.assertBalance('http://localhost:3001', 'alice', '99.9897')
-    yield services.assertBalance('http://localhost:3001', 'mark', '1000.0103')
-
-    yield services.assertBalance('http://localhost:3002', 'mark', '999.9898')
-    yield services.assertBalance('http://localhost:3002', 'mary', '1000.0102')
-
-    // Bob should have:
-    //    100      USD
-    //  +   0.01   USD (money from Alice)
-    //  ==============
-    //    100.01   USD
-    yield services.assertBalance('http://localhost:3003', 'bob', '100.01')
-    yield services.assertBalance('http://localhost:3003', 'mary', '999.99')
-    yield services.assertZeroHold()
-  })
-
-  it('transfers a small amount (by source amount)', function * () {
-    const receiverId = 'universal-0005'
-    yield services.sendPayment({
-      sourceAccount: 'http://localhost:3001/accounts/alice',
-      sourcePassword: 'alice',
-      destinationAccount: 'http://localhost:3003/accounts/bob',
-      sourceAmount: '0.01',
-      receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
-      destinationMemo: { receiverId }
-    })
-    yield Promise.delay(2000)
-    // Alice should have:
-    //    100      USD
-    //  -   0.01   USD (sent to Bob)
-    //  ==============
-    //     99.99   USD
-    yield services.assertBalance('http://localhost:3001', 'alice', '99.99')
-    yield services.assertBalance('http://localhost:3001', 'mark', '1000.01')
-
-    yield services.assertBalance('http://localhost:3002', 'mark', '999.9901')
-    yield services.assertBalance('http://localhost:3002', 'mary', '1000.0099')
-
-    // Bob should have:
-    //    100       USD
-    //  +   0.01    USD (money from Alice)
-    //  -   0.00002 USD (mary: connector spread/fee)
-    //  -   0.0001  USD (mary: 1/10^scale)
-    //  -   0.00002 USD (mark: connector spread/fee)
-    //  -   0.0001  USD (mark: 1/10^scale)
-    //  -   0.00001 USD (mark: quoted connector slippage)
-    //  -   0.00005 USD (mark: round destination amount down)
-    //  ==============
-    //    100.0097  USD
-    yield services.assertBalance('http://localhost:3003', 'Bob', '100.0097')
-    yield services.assertBalance('http://localhost:3003', 'mary', '999.9903')
-    yield services.assertZeroHold()
-  })
-})
-
-describe('send atomic payment', function () {
-  it('transfers the funds', function * () {
-    const receiverId = 'atomic-0001'
-    yield services.sendPayment({
-      sourceAccount: 'http://localhost:3001/accounts/alice',
-      sourcePassword: 'alice',
-      destinationAccount: 'http://localhost:3002/accounts/bob',
-      destinationAmount: '5',
-      notary: 'http://localhost:6001',
-      notaryPublicKey,
-      receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
-      destinationMemo: { receiverId }
-    })
-    yield Promise.delay(2000)
-    // Alice should have:
-    //    100      USD
-    //  -   5      USD (sent to Bob)
-    //  -   0.01   USD (connector spread/fee)
-    //  -   0.0001 USD (connector rounding in its favor)
-    //  -   0.0001 USD (mark: 1/10^scale)
-    //  -   0.005  USD (mark: quoted connector slippage)
-    //  ==============
-    //     94.9848 USD
-    yield services.assertBalance('http://localhost:3001', 'alice', '94.9848')
-    yield services.assertBalance('http://localhost:3001', 'mark', '1005.0152')
-
-    // Bob should have:
-    //    100      USD
-    //  +   5      USD (money from Alice)
-    //  ==============
-    //    105      USD
-    yield services.assertBalance('http://localhost:3002', 'bob', '105')
-    yield services.assertBalance('http://localhost:3002', 'mark', '995')
-    yield services.assertZeroHold()
-  })
-})
-
-describe('send same-ledger payment', function () {
-  it('transfers the funds', function * () {
-    const receiverId = 'same-ledger-0001'
-    yield services.sendPayment({
-      sourceAccount: 'http://localhost:3001/accounts/alice',
-      sourcePassword: 'alice',
-      destinationAccount: 'http://localhost:3001/accounts/bob',
-      destinationAmount: '5',
-      receiptCondition: services.createReceiptCondition(receiverSecret, receiverId),
-      destinationMemo: { receiverId }
-    })
-    yield Promise.delay(2000)
-    // Alice should have:
-    //    100      USD
-    //  -   5      USD (sent to Bob)
-    //  ==============
-    //     95      USD
-    yield services.assertBalance('http://localhost:3001', 'alice', '95')
-    yield services.assertBalance('http://localhost:3001', 'bob', '105')
-    yield services.assertBalance('http://localhost:3001', 'mark', '1000')
-    yield services.assertZeroHold()
   })
 })

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -17,6 +17,8 @@ before(function * () {
   yield graph.startLedger('ledger2', 3002, {})
   yield graph.startLedger('ledger3', 3003, {})
 
+  yield graph.setupAccounts()
+
   yield graph.startConnector('mark', 4001, {
     edges: [
       {source: 'http://localhost:3001', target: 'http://localhost:3002'}

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -2,6 +2,8 @@
 const childProcess = require('child_process')
 const Promise = require('bluebird')
 const waitOn = require('wait-on')
+const byline = require('byline')
+const through2 = require('through2')
 
 /**
  * Utility function for spawning processes.
@@ -28,24 +30,60 @@ function spawn (cmd, args, opts) {
  *
  * @return {Promise<ChildProcess>} Promise of the exit code of the process.
  */
-function spawnAndWait (cmd, args, opts, waitFor) {
-  return new Promise((resolve, reject) => {
-    const proc = childProcess.spawn(cmd, args,
-      Object.assign({}, opts, {stdio: 'pipe'}))
-    proc.on('error', reject)
+function spawnParallel (cmd, args, opts, formatter) {
+  const proc = childProcess.spawn(cmd, args,
+    Object.assign({}, opts, {stdio: 'pipe'}))
+
+  // Add prefix to output to distinguish processes
+  if (typeof formatter === 'function') {
+    const stdoutStream = byline(proc.stdout).pipe(through2(formatter))
+    const stderrStream = byline(proc.stderr).pipe(through2(formatter))
+
+    // Increase event listener limit to avoid memory leak warning
+    process.stdout.setMaxListeners(process.stdout.getMaxListeners() + 1)
+    process.stderr.setMaxListeners(process.stderr.getMaxListeners() + 1)
+    stdoutStream.pipe(process.stdout)
+    stderrStream.pipe(process.stderr)
+    proc.on('exit', () => {
+      // Disconnect pipes
+      stdoutStream.unpipe(process.stdout)
+      stderrStream.unpipe(process.stderr)
+
+      // Return to previous event emitter limit
+      process.stdout.setMaxListeners(process.stdout.getMaxListeners() - 1)
+      process.stderr.setMaxListeners(process.stderr.getMaxListeners() - 1)
+    })
+  } else {
     proc.stdout.on('data', (data) => process.stdout.write(data.toString()))
     proc.stderr.on('data', (data) => process.stderr.write(data.toString()))
-    if (typeof waitFor === 'string') {
-      waitFor = { resources: [waitFor] }
+  }
+
+  // When a process dies, we should abort
+  proc.on('exit', (code) => {
+    if (code) {
+      console.error('child exited with code ' + code)
+      process.exit(1)
     }
+  })
+
+  return proc
+}
+
+function wait (waitFor) {
+  if (typeof waitFor === 'string') {
+    waitFor = { resources: [waitFor] }
+  }
+
+  return new Promise((resolve, reject) => {
     waitOn(waitFor, function (err) {
       if (err) return reject(err)
-      resolve(proc)
+      resolve()
     })
   })
 }
 
 module.exports = {
   spawn,
-  spawnAndWait
+  spawnParallel,
+  wait
 }


### PR DESCRIPTION
We removed autofunding from the connector, which means we need to ensure the connector accounts exist before the connectors are started.

Also improves logging from this:

![screenshot from 2016-06-25 10-56-21](https://cloud.githubusercontent.com/assets/53233/16358282/dbd21c54-3ac3-11e6-8894-a1a3a55b5de7.png)

To this:

![screenshot from 2016-06-25 10-56-51](https://cloud.githubusercontent.com/assets/53233/16358288/e166671a-3ac3-11e6-9bb0-40aa4891fb34.png)

