### PR TITLE
fix: get git branch when running locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "chalk": "^1.1.3",
     "co-mocha": "^1.1.2",
     "five-bells-condition": "^3.0.0",
+    "git-branch": "^0.3.0",
     "mocha": "^2.4.5",
     "node-fetch": "^1.3.3",
     "superagent": "^1.7.2",

--- a/src/lib/dependency-manager.js
+++ b/src/lib/dependency-manager.js
@@ -5,6 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const fetch = require('node-fetch')
 const spawn = require('../util').spawn
+const gitBranch = require('git-branch')
 
 const DEFAULT_DEPENDENCIES = {
   'five-bells-ledger': 'interledger/five-bells-ledger#master',
@@ -46,7 +47,12 @@ class DependencyManager {
    * @return {String|null} Branch under test
    */
   getBranchNameUnderTest () {
-    const branch = process.env.CIRCLE_BRANCH
+    let branch = process.env.CIRCLE_BRANCH
+    if (!branch) {
+      try {
+        branch = gitBranch.sync(this.workDir)
+      } catch (e) {}
+    }
     if (typeof branch !== 'string') return null
     else if (branch === 'master') return null
     else return branch


### PR DESCRIPTION
the dependency manager was only using the env variable CIRCLE_BRANCH to check out the branches of dependencies. this meant it could only be run properly on CircleCI. this makes it look for the branch when run locally as well.