### PR TITLE
feat: BREAKING use new credentials format

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "bluebird": "^3.3.0",
     "bluebird-co": "^2.1.2",
     "co-mocha": "^1.1.2",
-    "five-bells-service-manager": "~1.0.1",
+    "five-bells-service-manager": "~2.0.0",
     "git-branch": "^0.3.0",
     "mocha": "^2.4.5",
     "node-fetch": "^1.3.3"

--- a/src/lib/service-graph.js
+++ b/src/lib/service-graph.js
@@ -109,9 +109,13 @@ class ServiceGraph {
   makeCredentials (ledgerPrefix, name) {
     const ledgerHost = this.services.ledgers[ledgerPrefix]
     return {
-      account: ledgerHost + '/accounts/' + encodeURIComponent(name),
-      username: name,
-      password: name
+      currency: 'USD',
+      plugin: 'ilp-plugin-bells',
+      options: {
+        account: ledgerHost + '/accounts/' + encodeURIComponent(name),
+        username: name,
+        password: name
+      }
     }
   }
 }


### PR DESCRIPTION
required by https://github.com/interledger/js-ilp-connector/pull/233 , and depends on https://github.com/interledger/five-bells-service-manager/pull/2 . The format of the connector's credentials will be changed.